### PR TITLE
Fix duplicate log save menu item

### DIFF
--- a/src/ui/menubar.py
+++ b/src/ui/menubar.py
@@ -75,13 +75,6 @@ class MenuBar:
         )
         file_menu.add_separator()
 
-        file_menu.add_command(
-            label=f"로그 저장 ({modifier}S)",
-            command=self.callbacks.get("save_log"),
-            accelerator=f"{modifier}S",
-        )
-        file_menu.add_separator()
-
         file_menu.add_command(label="종료", command=self.root.quit)
 
     def create_edit_menu(self):


### PR DESCRIPTION
## Summary
- remove redundant `로그 저장` menu item in `menubar.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f545a27988327bb2dd4d41f1c8c42