### PR TITLE
Fix dialog docstring

### DIFF
--- a/src/ui/dialogs.py
+++ b/src/ui/dialogs.py
@@ -101,5 +101,5 @@ class LogWindow:
         self.window.destroy()
 
     def is_alive(self) -> bool:
-        """창이 남아있는지 화인"""
+        """창이 남아있는지 확인"""
         return self._alive and self.window.winfo_exists()


### PR DESCRIPTION
## Summary
- fix typo in Korean docstring for `is_alive`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f5458f1188327b591003141d90b40